### PR TITLE
feat: add --version option

### DIFF
--- a/ruff_lsp/__init__.py
+++ b/ruff_lsp/__init__.py
@@ -1,3 +1,8 @@
-from importlib.metadata import version
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
 
 __version__ = version("ruff-lsp")

--- a/ruff_lsp/__init__.py
+++ b/ruff_lsp/__init__.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version("ruff-lsp")

--- a/ruff_lsp/__main__.py
+++ b/ruff_lsp/__main__.py
@@ -1,7 +1,24 @@
+import argparse
+import sys
+
+from ruff_lsp import __version__
+
+
 def main() -> None:
     from ruff_lsp.server import LSP_SERVER
 
-    LSP_SERVER.start_io()
+    parser = argparse.ArgumentParser(prog="ruff-lsp")
+    parser.add_argument(
+        "--version",
+        help="display version information and exit",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    if args.version:
+        print(__version__)
+        sys.exit(0)
+    else:
+        LSP_SERVER.start_io()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi, Thanks for a great tool (`ruff`, `ruff-lsp`). 🙇

I thought it would be useful to have a `--version` option in `ruff-lsp`, so I added it. If you do not need this PR, please close it.

**AFTER**:

<img width="396" alt="ruff-lsp-version-option" src="https://user-images.githubusercontent.com/188642/209054783-4c05be06-eee5-4a3b-b97d-bd4237c31f9c.png">
