### PR TITLE
Update neovim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ local on_attach = function(client, bufnr)
 end
 
 -- Configure `ruff-lsp`.
+-- See: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff_lsp
+-- For the default config, along with instructions on how to customize the settings
 require('lspconfig').ruff_lsp.setup {
   on_attach = on_attach,
 }

--- a/README.md
+++ b/README.md
@@ -75,21 +75,6 @@ local on_attach = function(client, bufnr)
 end
 
 -- Configure `ruff-lsp`.
-local configs = require 'lspconfig.configs'
-if not configs.ruff_lsp then
-  configs.ruff_lsp = {
-    default_config = {
-      cmd = { 'ruff-lsp' },
-      filetypes = { 'python' },
-      root_dir = require('lspconfig').util.find_git_ancestor,
-      init_options = {
-        settings = {
-          args = {}
-        }
-      } 
-    }
-  }
-end
 require('lspconfig').ruff_lsp.setup {
   on_attach = on_attach,
 }


### PR DESCRIPTION
nvim-lspconfig now supports ruff-lsp by default, which allows reducing some overhead in the config