### PR TITLE
ruff fromEnvironment (vscode extension) not found under windows

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -66,7 +66,7 @@ LSP_SERVER = server.LanguageServer(
     max_workers=MAX_WORKERS,
 )
 
-TOOL_MODULE = "ruff"
+TOOL_MODULE = "ruff.exe" if os.name == "nt" else "ruff"
 TOOL_DISPLAY = "Ruff"
 TOOL_ARGS = ["--no-cache", "--no-fix", "--quiet", "--format", "json", "-"]
 

--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 import pathlib
+import platform
 import re
 import sys
 import sysconfig
@@ -66,7 +67,7 @@ LSP_SERVER = server.LanguageServer(
     max_workers=MAX_WORKERS,
 )
 
-TOOL_MODULE = "ruff.exe" if os.name == "nt" else "ruff"
+TOOL_MODULE = "ruff.exe" if platform.system() == "Windows" else "ruff"
 TOOL_DISPLAY = "Ruff"
 TOOL_ARGS = ["--no-cache", "--no-fix", "--quiet", "--format", "json", "-"]
 


### PR DESCRIPTION
**Problem:** vscode with ruff strategy `fromEnvironment` throws the following error under windows
```
        Interpreter executable (./venv/py310/Scripts/ruff) not found; falling back to bundled executable
```

Sadly under windows ruff has the `.exe` extension, thus not found.

**This pr** fixes that