### PR TITLE
Prioritize use of ruff commands installed in the environment

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import platform
 import re
+import shutil
 import sys
 import sysconfig
 from typing import Any, Sequence, cast
@@ -727,7 +728,11 @@ def _executable_path(settings: dict[str, Any]) -> str:
     # If the interpreter is same as the interpreter running this process, get the
     # script path directly.
     path = os.path.join(sysconfig.get_path("scripts"), TOOL_MODULE)
-    if bundle and not os.path.exists(path):
+    environment_path = shutil.which("ruff")
+    if environment_path:
+        log_to_output(f"Using environment executable: {environment_path}")
+        path = environment_path
+    elif bundle and not os.path.exists(path):
         log_to_output(
             f"Interpreter executable ({path}) not found; "
             f"falling back to bundled executable: {bundle}"


### PR DESCRIPTION
Create a virtual environment (project) with `venv`, `poetry`, etc., activated the virtual environment, and install the `ruff` command inside the virtual environment.

Currently, To use the `ruff` command installed in this virtual environment with `ruff-lsp`, explicitly set the ruff path or interpreter (settings) to the language server. This must be done every time for all projects that use ruff.

If the above settings are not made, the ruff command installed with ruff-lsp will be used. It may be different from the version of the ruff command installed in your project.

I added code to detect the `ruff` command installed in the project and use it preferentially.

