### PR TITLE
Add ruff.organizeImports workspace command

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -454,7 +454,7 @@ def apply_autofix(arguments: tuple[TextDocument]):
     )
 
 
-@LSP_SERVER.command("ruff.organizeImports")
+@LSP_SERVER.command("ruff.applyOrganizeImports")
 def apply_organize_imports(arguments: tuple[TextDocument]):
     uri = arguments[0]["uri"]
     text_document = LSP_SERVER.workspace.get_document(uri)
@@ -462,7 +462,7 @@ def apply_organize_imports(arguments: tuple[TextDocument]):
         _create_workspace_edits(
             text_document, _formatting_helper(text_document, only="I001") or []
         ),
-        "Ruff: Organize Imports",
+        "Ruff: Format imports",
     )
 
 

--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -454,6 +454,18 @@ def apply_autofix(arguments: tuple[TextDocument]):
     )
 
 
+@LSP_SERVER.command("ruff.organizeImports")
+def apply_organize_imports(arguments: tuple[TextDocument]):
+    uri = arguments[0]["uri"]
+    text_document = LSP_SERVER.workspace.get_document(uri)
+    LSP_SERVER.apply_edit(
+        _create_workspace_edits(
+            text_document, _formatting_helper(text_document, only="I001") or []
+        ),
+        "Ruff: Organize Imports",
+    )
+
+
 def _formatting_helper(
     document: workspace.Document, *, only: str | None = None
 ) -> list[TextEdit] | None:


### PR DESCRIPTION
Added support for `ruff.organizeImports` as a workspace command.

I couldn't properly test because I got very frustrated due to not being able to disable organize imports and fix all code actions. I didn't get to testing that this command would work properly. Wanted to post it though as others may be able to test easier and/or I can come back a little later and try again.

Fixes #54 

Thanks.