### PR TITLE
Find ruff in PATH as fallback

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import platform
 import re
+import shutil
 import sys
 import sysconfig
 from typing import Any, Sequence, cast
@@ -765,12 +766,18 @@ def _executable_path(settings: dict[str, Any]) -> str:
     # If the interpreter is same as the interpreter running this process, get the
     # script path directly.
     path = os.path.join(sysconfig.get_path("scripts"), TOOL_MODULE)
-    if bundle and not os.path.exists(path):
-        log_to_output(
-            f"Interpreter executable ({path}) not found; "
-            f"falling back to bundled executable: {bundle}"
-        )
-        path = bundle
+    if not os.path.exists(path):
+        env_path = shutil.which(TOOL_MODULE)
+        if env_path is not None:
+            log_to_output(f"Using executable found in PATH: {env_path}")
+            path = env_path
+        elif bundle:
+            log_to_output(
+                f"Interpreter executable ({path}) not found; "
+                f"no executable found in PATH either; "
+                f"falling back to bundled executable: {bundle}"
+            )
+            path = bundle
     else:
         log_to_output(f"Using interpreter executable: {path}")
     return path


### PR DESCRIPTION
ruff might not always be installed in the python interpreter's scripts directory.
I'm in the process of packaging ruff-lsp for nixpkgs and the fact that ruff-lsp only looks in python's script directory makes it very hard to package in the context of nix since that directory will only ever include the default python binaries.

This PR solves that issue by also looking for a ruff executable in the regular binary PATH.