### PR TITLE
doc: add extra pointers to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ end
 -- For the default config, along with instructions on how to customize the settings
 require('lspconfig').ruff_lsp.setup {
   on_attach = on_attach,
+  init_options = {
+    settings = {
+      -- Any extra CLI arguments for `ruff` go here.
+      args = {},
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
I think it would be helpful to call out that `settings` go under `init_options`.  It was in the docs linked in the comments, but that took me a little too long to figure out.  Maybe this would help others.