### PR TITLE
Add support for Ruff's multiple-edit output format

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -64,10 +64,14 @@ class TestServer(unittest.TestCase):
                             },
                             "data": {
                                 "fix": {
-                                    "content": "",
                                     "message": "Remove unused import: `sys`",
-                                    "location": {"row": 1, "column": 0},
-                                    "end_location": {"row": 2, "column": 0},
+                                    "edits": [
+                                        {
+                                            "content": "",
+                                            "location": {"row": 1, "column": 0},
+                                            "end_location": {"row": 2, "column": 0},
+                                        }
+                                    ],
                                 },
                                 "noqa_row": 1,
                             },
@@ -143,10 +147,14 @@ class TestServer(unittest.TestCase):
                             },
                             "data": {
                                 "fix": {
-                                    "content": "",
                                     "message": "Remove unused import: `sys`",
-                                    "location": {"row": 1, "column": 0},
-                                    "end_location": {"row": 2, "column": 0},
+                                    "edits": [
+                                        {
+                                            "content": "",
+                                            "location": {"row": 1, "column": 0},
+                                            "end_location": {"row": 2, "column": 0},
+                                        }
+                                    ],
                                 },
                                 "noqa_row": 1,
                             },


### PR DESCRIPTION
## Summary

This PR updates the LSP to match the changes to Ruff's output format introduced in https://github.com/charliermarsh/ruff/pull/3709 (which will go out in Ruff v0.0.260).

The change is backwards-compatible, such that the LSP will continue to support older versions of Ruff. Note, however, that _newer_ versions of Ruff will require an LSP update.
