### PR TITLE
Avoid setting `cwd` for files outside of workspace

### DIFF
--- a/ruff_lsp/server.py
+++ b/ruff_lsp/server.py
@@ -788,6 +788,7 @@ def _update_workspace_settings(settings: list[dict[str, Any]]) -> None:
         workspace_path = os.getcwd()
         WORKSPACE_SETTINGS[workspace_path] = {
             **_default_settings(),
+            "cwd": workspace_path,
             "workspaceFS": workspace_path,
             "workspace": uris.from_fs_path(workspace_path),
         }
@@ -799,6 +800,7 @@ def _update_workspace_settings(settings: list[dict[str, Any]]) -> None:
             WORKSPACE_SETTINGS[workspace_path] = {
                 **_default_settings(),
                 **setting,
+                "cwd": workspace_path,
                 "workspaceFS": workspace_path,
                 "workspace": setting["workspace"],
             }
@@ -807,6 +809,7 @@ def _update_workspace_settings(settings: list[dict[str, Any]]) -> None:
             WORKSPACE_SETTINGS[workspace_path] = {
                 **_default_settings(),
                 **setting,
+                "cwd": workspace_path,
                 "workspaceFS": workspace_path,
                 "workspace": uris.from_fs_path(workspace_path),
             }
@@ -832,6 +835,7 @@ def _get_settings_by_document(document: workspace.Document | None) -> dict[str, 
         workspace_path = os.fspath(pathlib.Path(document.path).parent)
         return {
             **_default_settings(),
+            "cwd": None,
             "workspaceFS": workspace_path,
             "workspace": uris.from_fs_path(workspace_path),
         }
@@ -951,7 +955,7 @@ def _run_tool_on_document(
     result: utils.RunResult = utils.run_path(
         argv=argv,
         use_stdin=use_stdin,
-        cwd=settings["workspaceFS"],
+        cwd=settings["cwd"],
         source=document.source.replace("\r\n", "\n"),
     )
     if result.stderr:
@@ -974,7 +978,7 @@ def _run_subcommand_on_document(
     result: utils.RunResult = utils.run_path(
         argv=argv,
         use_stdin=False,
-        cwd=settings["workspaceFS"],
+        cwd=settings["cwd"],
     )
     if result.stderr:
         log_to_output(result.stderr)

--- a/ruff_lsp/utils.py
+++ b/ruff_lsp/utils.py
@@ -73,7 +73,7 @@ class RunResult:
 def run_path(
     argv: Sequence[str],
     use_stdin: bool,
-    cwd: str,
+    cwd: str | None = None,
     source: str | None = None,
 ) -> RunResult:
     """Runs as an executable."""


### PR DESCRIPTION
## Summary

I noticed that in the VS Code extension, if I add an exclude for files outside of the workspace, e.g. with this `settings.json`:

```json
{
    "ruff.args": [
        "--extend-exclude",
        ".vscode"
    ]
}
```

Then when opening files in `.vscode`, I was still seeing lint errors. That is, the exclusion wasn't respected.

I had to dig into Ruff internals, but the issue is that we're setting the `cwd` to the parent directory of the file. So if the file is `/Users/crmarsh/.vscode/versions/3.12.0a3/lib/python3.12/runpy.py`, we set the `cwd` to `/Users/crmarsh/.vscode/versions/3.12.0a3/lib/python3.12`. This causes us to short-circuit when we look for exclusions along the filepath, since we avoid looking at exclusions beyond the project root.

Instead, let's try not setting any `cwd` at all for files outside of the workspace.
