### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "12:00"


### PR DESCRIPTION
This should enable dependency update PRs.

Not sure how exactly it will work in this repo. It will surely provide dependency updates listed in `requirements.txt` but probably not in `requirements-dev.txt`. Also not sure if it will handle `pyproject.toml` but [it should](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pip-and-pip-compile).

I suppose it can be merged and tried and maybe tweaked later.